### PR TITLE
Add move button helper

### DIFF
--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -289,6 +289,28 @@ local customDiceSpawnButton = {
     press_color = {0.27, 0.27, 0.27, 1}, -- Slightly lighter gray when pressed
     scale = {0.5, 0.5, 0.5}
 }
+-- Input for moving existing buttons on the fly
+local moveBtnInput = {
+    index = 1,
+    label = "index,x,z",
+    input_function = "updateMoveBtnInput",
+    function_owner = self,
+    position = {6.9, Yoffset, 1.20}, rotation = {0, 0, 0},
+    width = 1100, height = 225, font_size = 180,
+    alignment = 2, scale = {0.5, 0.5, 0.5},
+    color = {1, 1, 1, 1}, font_color = {0.2, 0.2, 0.2}
+}
+
+-- Button that triggers the reposition
+local moveBtnButton = {
+    label = "Move Btn", click_function = "applyMoveBtn", function_owner = self,
+    position = {6.9, Yoffset, 1.54}, rotation = {0, 0, 0},
+    width = 1300, height = 300, font_size = 150,
+    color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
+    hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
+    scale = {0.5, 0.5, 0.5}
+}
+local moveBtnInputText = ""
 local customDiceCount = 1 -- Default number of dice
 
 lethalHitsThreshold = 6
@@ -1056,7 +1078,9 @@ function onload()
     self.createButton(auto2D6)
     self.createButton(revertRollBtn)  -- Add this near the end of the button creations
     self.createInput(customDiceInput)
+    self.createInput(moveBtnInput)
     self.createButton(customDiceSpawnButton)
+    self.createButton(moveBtnButton)
     self.createButton(customDiceInputBG)
     if self.getPosition().z < 0 then selectedColor="Blue" else selectedColor="Red" end modifyMenu(selectedColor)
 
@@ -1694,4 +1718,23 @@ function swapPipColor()
     setDiceType()
 
     self.editButton(pipColorBtn)
+end
+
+-- Store the text from the move button input
+function updateMoveBtnInput(_, _, value, _)
+    moveBtnInputText = value
+end
+
+-- Parse input and reposition the specified button
+function applyMoveBtn(_, player, _)
+    local index, x, z = string.match(moveBtnInputText or '', '%s*(%d+)%s*,%s*([%-%.%d]+)%s*,%s*([%-%.%d]+)')
+    if not index then
+        printToColor('Format: index,x,z', player, 'Red')
+        return
+    end
+    index = tonumber(index)
+    x = tonumber(x)
+    z = tonumber(z)
+    self.editButton({ index = index, position = { x, Yoffset, z } })
+    printToColor('Moved button ' .. index .. ' to (' .. x .. ', ' .. z .. ')', player, 'Green')
 end

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -334,7 +334,28 @@ local moveBtnRightButton = {
     hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
     scale = {0.5, 0.5, 0.5}
 }
+
+-- Input for absolute positioning ("id,x,z") and the trigger button
+local moveBtnCoordsInput = {
+    index = 2,
+    label = "id,x,z",
+    input_function = "updateMoveBtnCoords",
+    function_owner = self,
+    position = {6.9, Yoffset, 2.22}, rotation = {0, 0, 0},
+    width = 1100, height = 225, font_size = 180,
+    alignment = 2, scale = {0.5, 0.5, 0.5},
+    color = {1, 1, 1, 1}, font_color = {0.2, 0.2, 0.2}
+}
+local moveBtnApplyButton = {
+    label = "Move Btn", click_function = "applyMoveBtn", function_owner = self,
+    position = {6.9, Yoffset, 2.56}, rotation = {0, 0, 0},
+    width = 1300, height = 300, font_size = 150,
+    color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
+    hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
+    scale = {0.5, 0.5, 0.5}
+}
 local moveBtnInputText = ""
+local moveBtnCoordsText = ""
 -- Track the last known position for edited buttons so repeated moves build on
 -- the latest coordinates.  This avoids relying on `getButtons`, which can
 -- return stale data after runtime modifications.
@@ -1112,6 +1133,8 @@ function onload()
     self.createButton(moveBtnDownButton)
     self.createButton(moveBtnLeftButton)
     self.createButton(moveBtnRightButton)
+    self.createInput(moveBtnCoordsInput)
+    self.createButton(moveBtnApplyButton)
     self.createButton(customDiceInputBG)
     if self.getPosition().z < 0 then selectedColor="Blue" else selectedColor="Red" end modifyMenu(selectedColor)
 
@@ -1647,7 +1670,7 @@ function checkDice ()
     diceSum = 0
 
     for _, obj in pairs(getAllObjects()) do
-        if obj != nil and obj.tag == 'Dice' and obj.resting then
+        if obj ~= nil and obj.tag == 'Dice' and obj.resting then
             local objPos = obj.getPosition()
             if objPos['x'] > leftBound and objPos['x'] < rightBound and objPos['z'] > lowerBound and objPos['z'] < upperBound and objPos['y'] < yupperBound and objPos['y'] > ylowerBound then
                 local value = obj.getValue()
@@ -1756,8 +1779,24 @@ function updateMoveBtnInput(_, _, value, _)
     moveBtnInputText = value
 end
 
+-- Update the absolute positioning text
+function updateMoveBtnCoords(_, _, value, _)
+    moveBtnCoordsText = value
+end
+
 -- Parse input and reposition the specified button
 -- Helper to move a button by a small offset
+local function getButtonPosition(idx)
+    local buttons = self.getButtons()
+    if not buttons then return nil end
+    for _, btn in ipairs(buttons) do
+        if btn.index == idx then
+            return { table.unpack(btn.position) }
+        end
+    end
+    return nil
+end
+
 local function moveButtonBy(index, dx, dz, player)
     index = tonumber(index)
     if not index then
@@ -1769,14 +1808,13 @@ local function moveButtonBy(index, dx, dz, player)
 
     local pos = moveBtnPositions[index]
     if not pos then
-        local buttons = self.getButtons()
-        if not buttons or not buttons[index] then
+        pos = getButtonPosition(index)
+        if not pos then
             if player then
                 printToColor('Invalid button id', player, 'Red')
             end
             return
         end
-        pos = {table.unpack(buttons[index].position)}
     end
 
     pos[1] = pos[1] + dx
@@ -1799,4 +1837,28 @@ end
 
 function moveBtnRight(_, player, _)
     moveButtonBy(tonumber(moveBtnInputText), 0.1, 0, player)
+end
+
+-- Move a button to an exact X/Z coordinate
+function applyMoveBtn(_, player, _)
+    if not moveBtnCoordsText or moveBtnCoordsText == "" then
+        printToColor('Format: id,x,z', player, 'Red')
+        return
+    end
+    local id, x, z = string.match(moveBtnCoordsText, "^%s*(%d+)%s*,%s*([%-%d%.]+)%s*,%s*([%-%d%.]+)%s*$")
+    id, x, z = tonumber(id), tonumber(x), tonumber(z)
+    if not (id and x and z) then
+        printToColor('Format: id,x,z', player, 'Red')
+        return
+    end
+
+    local pos = getButtonPosition(id)
+    if not pos then
+        printToColor('Invalid button id', player, 'Red')
+        return
+    end
+
+    pos[1], pos[3] = x, z
+    moveBtnPositions[id] = pos
+    self.editButton({ index = id, position = pos })
 end

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -289,10 +289,10 @@ local customDiceSpawnButton = {
     press_color = {0.27, 0.27, 0.27, 1}, -- Slightly lighter gray when pressed
     scale = {0.5, 0.5, 0.5}
 }
--- Input for moving existing buttons on the fly
+-- Input for specifying the button to move
 local moveBtnInput = {
     index = 1,
-    label = "index,x,z",
+    label = "btn id",
     input_function = "updateMoveBtnInput",
     function_owner = self,
     position = {6.9, Yoffset, 1.20}, rotation = {0, 0, 0},
@@ -301,11 +301,35 @@ local moveBtnInput = {
     color = {1, 1, 1, 1}, font_color = {0.2, 0.2, 0.2}
 }
 
--- Button that triggers the reposition
-local moveBtnButton = {
-    label = "Move Btn", click_function = "applyMoveBtn", function_owner = self,
+-- Directional movement buttons
+local moveBtnUp = {
+    label = "Up", click_function = "moveBtnUp", function_owner = self,
     position = {6.9, Yoffset, 1.54}, rotation = {0, 0, 0},
-    width = 1300, height = 300, font_size = 150,
+    width = 600, height = 300, font_size = 150,
+    color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
+    hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
+    scale = {0.5, 0.5, 0.5}
+}
+local moveBtnDown = {
+    label = "Down", click_function = "moveBtnDown", function_owner = self,
+    position = {6.9, Yoffset, 1.88}, rotation = {0, 0, 0},
+    width = 600, height = 300, font_size = 150,
+    color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
+    hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
+    scale = {0.5, 0.5, 0.5}
+}
+local moveBtnLeft = {
+    label = "Left", click_function = "moveBtnLeft", function_owner = self,
+    position = {6.5, Yoffset, 1.71}, rotation = {0, 0, 0},
+    width = 600, height = 300, font_size = 150,
+    color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
+    hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
+    scale = {0.5, 0.5, 0.5}
+}
+local moveBtnRight = {
+    label = "Right", click_function = "moveBtnRight", function_owner = self,
+    position = {7.3, Yoffset, 1.71}, rotation = {0, 0, 0},
+    width = 600, height = 300, font_size = 150,
     color = {0.13, 0.13, 0.13, 1}, font_color = {1, 1, 1},
     hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
     scale = {0.5, 0.5, 0.5}
@@ -1080,7 +1104,10 @@ function onload()
     self.createInput(customDiceInput)
     self.createInput(moveBtnInput)
     self.createButton(customDiceSpawnButton)
-    self.createButton(moveBtnButton)
+    self.createButton(moveBtnUp)
+    self.createButton(moveBtnDown)
+    self.createButton(moveBtnLeft)
+    self.createButton(moveBtnRight)
     self.createButton(customDiceInputBG)
     if self.getPosition().z < 0 then selectedColor="Blue" else selectedColor="Red" end modifyMenu(selectedColor)
 
@@ -1726,15 +1753,38 @@ function updateMoveBtnInput(_, _, value, _)
 end
 
 -- Parse input and reposition the specified button
-function applyMoveBtn(_, player, _)
-    local index, x, z = string.match(moveBtnInputText or '', '%s*(%d+)%s*,%s*([%-%.%d]+)%s*,%s*([%-%.%d]+)')
+-- Helper to move a button by a small offset
+local function moveButtonBy(index, dx, dz, player)
+    index = tonumber(index)
     if not index then
-        printToColor('Format: index,x,z', player, 'Red')
+        if player then
+            printToColor('Enter a button id', player, 'Red')
+        end
         return
     end
-    index = tonumber(index)
-    x = tonumber(x)
-    z = tonumber(z)
-    self.editButton({ index = index, position = { x, Yoffset, z } })
-    printToColor('Moved button ' .. index .. ' to (' .. x .. ', ' .. z .. ')', player, 'Green')
+    local buttons = self.getButtons()
+    if not buttons or not buttons[index] then
+        if player then
+            printToColor('Invalid button id', player, 'Red')
+        end
+        return
+    end
+    local pos = buttons[index].position
+    self.editButton({ index = index, position = { pos[1] + dx, pos[2], pos[3] + dz } })
+end
+
+function moveBtnUp(_, player, _)
+    moveButtonBy(tonumber(moveBtnInputText), 0, 0.1, player)
+end
+
+function moveBtnDown(_, player, _)
+    moveButtonBy(tonumber(moveBtnInputText), 0, -0.1, player)
+end
+
+function moveBtnLeft(_, player, _)
+    moveButtonBy(tonumber(moveBtnInputText), -0.1, 0, player)
+end
+
+function moveBtnRight(_, player, _)
+    moveButtonBy(tonumber(moveBtnInputText), 0.1, 0, player)
 end

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -290,7 +290,7 @@ local customDiceSpawnButton = {
     scale = {0.5, 0.5, 0.5}
 }
 -- Input for specifying the button to move
-local moveBtnInput = {
+local moveBtnInputSpec = {
     index = 1,
     label = "btn id",
     input_function = "updateMoveBtnInput",
@@ -302,7 +302,7 @@ local moveBtnInput = {
 }
 
 -- Directional movement buttons
-local moveBtnUp = {
+local moveBtnUpButton = {
     label = "Up", click_function = "moveBtnUp", function_owner = self,
     position = {6.9, Yoffset, 1.54}, rotation = {0, 0, 0},
     width = 600, height = 300, font_size = 150,
@@ -310,7 +310,7 @@ local moveBtnUp = {
     hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
     scale = {0.5, 0.5, 0.5}
 }
-local moveBtnDown = {
+local moveBtnDownButton = {
     label = "Down", click_function = "moveBtnDown", function_owner = self,
     position = {6.9, Yoffset, 1.88}, rotation = {0, 0, 0},
     width = 600, height = 300, font_size = 150,
@@ -318,7 +318,7 @@ local moveBtnDown = {
     hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
     scale = {0.5, 0.5, 0.5}
 }
-local moveBtnLeft = {
+local moveBtnLeftButton = {
     label = "Left", click_function = "moveBtnLeft", function_owner = self,
     position = {6.5, Yoffset, 1.71}, rotation = {0, 0, 0},
     width = 600, height = 300, font_size = 150,
@@ -326,7 +326,7 @@ local moveBtnLeft = {
     hover_color = {0.2, 0.2, 0.2, 1}, press_color = {0.27, 0.27, 0.27, 1},
     scale = {0.5, 0.5, 0.5}
 }
-local moveBtnRight = {
+local moveBtnRightButton = {
     label = "Right", click_function = "moveBtnRight", function_owner = self,
     position = {7.3, Yoffset, 1.71}, rotation = {0, 0, 0},
     width = 600, height = 300, font_size = 150,
@@ -1102,12 +1102,12 @@ function onload()
     self.createButton(auto2D6)
     self.createButton(revertRollBtn)  -- Add this near the end of the button creations
     self.createInput(customDiceInput)
-    self.createInput(moveBtnInput)
+    self.createInput(moveBtnInputSpec)
     self.createButton(customDiceSpawnButton)
-    self.createButton(moveBtnUp)
-    self.createButton(moveBtnDown)
-    self.createButton(moveBtnLeft)
-    self.createButton(moveBtnRight)
+    self.createButton(moveBtnUpButton)
+    self.createButton(moveBtnDownButton)
+    self.createButton(moveBtnLeftButton)
+    self.createButton(moveBtnRightButton)
     self.createButton(customDiceInputBG)
     if self.getPosition().z < 0 then selectedColor="Blue" else selectedColor="Red" end modifyMenu(selectedColor)
 

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -335,6 +335,10 @@ local moveBtnRightButton = {
     scale = {0.5, 0.5, 0.5}
 }
 local moveBtnInputText = ""
+-- Track the last known position for edited buttons so repeated moves build on
+-- the latest coordinates.  This avoids relying on `getButtons`, which can
+-- return stale data after runtime modifications.
+local moveBtnPositions = {}
 local customDiceCount = 1 -- Default number of dice
 
 lethalHitsThreshold = 6
@@ -1762,23 +1766,31 @@ local function moveButtonBy(index, dx, dz, player)
         end
         return
     end
-    local buttons = self.getButtons()
-    if not buttons or not buttons[index] then
-        if player then
-            printToColor('Invalid button id', player, 'Red')
+
+    local pos = moveBtnPositions[index]
+    if not pos then
+        local buttons = self.getButtons()
+        if not buttons or not buttons[index] then
+            if player then
+                printToColor('Invalid button id', player, 'Red')
+            end
+            return
         end
-        return
+        pos = {table.unpack(buttons[index].position)}
     end
-    local pos = buttons[index].position
-    self.editButton({ index = index, position = { pos[1] + dx, pos[2], pos[3] + dz } })
+
+    pos[1] = pos[1] + dx
+    pos[3] = pos[3] + dz
+    moveBtnPositions[index] = pos
+    self.editButton({ index = index, position = pos })
 end
 
 function moveBtnUp(_, player, _)
-    moveButtonBy(tonumber(moveBtnInputText), 0, 0.1, player)
+    moveButtonBy(tonumber(moveBtnInputText), 0, -0.1, player)
 end
 
 function moveBtnDown(_, player, _)
-    moveButtonBy(tonumber(moveBtnInputText), 0, -0.1, player)
+    moveButtonBy(tonumber(moveBtnInputText), 0, 0.1, player)
 end
 
 function moveBtnLeft(_, player, _)


### PR DESCRIPTION
## Summary
- allow moving UI buttons on the fly
- add `updateMoveBtnInput` and `applyMoveBtn` helpers

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570840c1448329800f1ac31b957278