### PR TITLE
Add off-line placement for large coherency groups

### DIFF
--- a/TTSLUA/controlBoard.ttslua
+++ b/TTSLUA/controlBoard.ttslua
@@ -278,6 +278,21 @@ function arrangeModelsWith2Inch(playerColor, value, id)
       end
     end
 
+    local count = #items
+
+    -- If we have more than 7 models, move one model at either end of the line
+    -- 2" away from the line. The rest remain in a straight line with 2" spacing.
+    if count > 7 then
+      local perp = { x = -d.z, z = d.x }
+      local offset = { x = perp.x * 2, z = perp.z * 2 }
+
+      items[1].newPos.x = items[1].newPos.x + offset.x
+      items[1].newPos.z = items[1].newPos.z + offset.z
+
+      items[count].newPos.x = items[count].newPos.x + offset.x
+      items[count].newPos.z = items[count].newPos.z + offset.z
+    end
+
     -- Apply the new positions to each model
     for _, item in ipairs(items) do
       item.obj.setPositionSmooth(item.newPos)

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -1916,6 +1916,22 @@ function arrangeModelsWith2Inch(a, b, c)
       }
     end
 
+    local count = #items
+
+    -- If we have more than 7 models, move one model at either end of the line
+    -- 2" away from the line of models. The remaining models stay in a line with
+    -- 2" spacing. This mirrors the typical coherency layout for large units.
+    if count > 7 then
+      local perp = { x = -d.z, z = d.x }
+      local offset = { x = perp.x * 2, z = perp.z * 2 }
+
+      items[1].newPos.x = items[1].newPos.x + offset.x
+      items[1].newPos.z = items[1].newPos.z + offset.z
+
+      items[count].newPos.x = items[count].newPos.x + offset.x
+      items[count].newPos.z = items[count].newPos.z + offset.z
+    end
+
     for _, item in ipairs(items) do
       item.obj.setPositionSmooth(item.newPos)
     end


### PR DESCRIPTION
## Summary
- update `arrangeModelsWith2Inch` in customDiceTable.ttslua
- update `arrangeModelsWith2Inch` in controlBoard.ttslua

## Testing
- `# no tests present`

------
https://chatgpt.com/codex/tasks/task_e_686063a1d530832987ea5e9c7a238548