### PR TITLE
Handle large squad arrangement

### DIFF
--- a/TTSLUA/controlBoard.ttslua
+++ b/TTSLUA/controlBoard.ttslua
@@ -278,6 +278,33 @@ function arrangeModelsWith2Inch(playerColor, value, id)
       end
     end
 
+    -- If the unit has more than 7 models, offset one model at either end so
+    -- that groups of four form at the ends (three in line, one 2" away).
+    if #items > 7 then
+      -- Perpendicular direction to offset models away from the line
+      local perp = { x = -d.z, z = d.x }
+
+      -- Index of the model to offset at the start of the line
+      local startIdx = 4
+      if items[startIdx] then
+        items[startIdx].newPos = {
+          x = items[startIdx].newPos.x + perp.x * 2,
+          y = items[startIdx].newPos.y,
+          z = items[startIdx].newPos.z + perp.z * 2
+        }
+      end
+
+      -- Index of the model to offset at the end of the line
+      local endIdx = #items - 3
+      if items[endIdx] then
+        items[endIdx].newPos = {
+          x = items[endIdx].newPos.x - perp.x * 2,
+          y = items[endIdx].newPos.y,
+          z = items[endIdx].newPos.z - perp.z * 2
+        }
+      end
+    end
+
     -- Apply the new positions to each model
     for _, item in ipairs(items) do
       item.obj.setPositionSmooth(item.newPos)

--- a/TTSLUA/customDiceTable.ttslua
+++ b/TTSLUA/customDiceTable.ttslua
@@ -1916,6 +1916,29 @@ function arrangeModelsWith2Inch(a, b, c)
       }
     end
 
+    -- If more than seven models are selected, offset one model at either end of
+    -- the line so each end forms a group of four (three in line, one 2" away).
+    if #items > 7 then
+      local perp = { x = -d.z, z = d.x }
+      local startIdx = 4
+      if items[startIdx] then
+        items[startIdx].newPos = {
+          x = items[startIdx].newPos.x + perp.x * 2,
+          y = items[startIdx].newPos.y,
+          z = items[startIdx].newPos.z + perp.z * 2
+        }
+      end
+
+      local endIdx = #items - 3
+      if items[endIdx] then
+        items[endIdx].newPos = {
+          x = items[endIdx].newPos.x - perp.x * 2,
+          y = items[endIdx].newPos.y,
+          z = items[endIdx].newPos.z - perp.z * 2
+        }
+      end
+    end
+
     for _, item in ipairs(items) do
       item.obj.setPositionSmooth(item.newPos)
     end


### PR DESCRIPTION
## Summary
- update model-arranging hotkeys to offset fourth model on each end if over 7 models

## Testing
- `luac -p TTSLUA/controlBoard.ttslua`
- `luac -p TTSLUA/customDiceTable.ttslua` *(fails: `then` expected near !)*

------
https://chatgpt.com/codex/tasks/task_e_686063a1d530832987ea5e9c7a238548